### PR TITLE
Add libffi-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:13-alpine3.10
 
-RUN apk add --update gcc libc-dev zeromq-dev python3-dev linux-headers
+RUN apk add --update gcc libc-dev zeromq-dev python3-dev linux-headers libffi-dev
 
 ARG NB_USER=leslie
 ARG NB_UID=1000


### PR DESCRIPTION
Currently docker build fails, which also breaks Binder. The reason is
that for the current version of argon2-cffi there is no binary wheel
for Python 3.7 on Linux, so it has to be compiled. This fails because
the libffi development files are missing.